### PR TITLE
Add missing repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "main": "dist/extensionParameterValidator.js",
   "types": "dist/extensionParameterValidator.d.ts",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/exasol/extension-parameter-validator"
+  },
   "scripts": {
     "build": "tsc --build",
     "clean": "tsc --build --clean",


### PR DESCRIPTION
This fixes the following error during publishing, see https://github.com/exasol/extension-parameter-validator/actions/runs/23892117885/job/69667745134
```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access npm notice publish Signed provenance statement with source and build information from GitHub Actions npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1214437406 npm error code E422 npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@exasol%2fextension-parameter-validator - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/exasol/extension-parameter-validator" from provenance
```